### PR TITLE
Fix Build Error

### DIFF
--- a/inventory-management-app/inventory-mgmt-service/pom.xml
+++ b/inventory-management-app/inventory-mgmt-service/pom.xml
@@ -7,6 +7,7 @@
 		<groupId>com.howtodoinjava</groupId>
 		<artifactId>Spring-Boot3-Demos</artifactId>
 		<version>1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 
 	<groupId>com.howtodoinjava</groupId>


### PR DESCRIPTION
Fix Build Error
```
[INFO] Scanning for projects...
[ERROR] [ERROR] Some problems were encountered while processing the POMs:
[FATAL] Non-resolvable parent POM for com.howtodoinjava:inventory-mgmt-service:0.0.1-SNAPSHOT: Could not find artifact com.howtodoinjava:Spring-Boot3-Demos:pom:1.0-SNAPSHOT and 'parent.relativePath' points at wrong local POM @ line 6, column 10
 @ 
[ERROR] The build could not read 1 project -> [Help 1]
[ERROR]   
[ERROR]   The project com.howtodoinjava:inventory-mgmt-service:0.0.1-SNAPSHOT (E:\Users\admin\CloneGitRepositry\Spring-Boot3-Demos\inventory-management-app\inventory-mgmt-service\pom.xml) has 1 error
[ERROR]     Non-resolvable parent POM for com.howtodoinjava:inventory-mgmt-service:0.0.1-SNAPSHOT: Could not find artifact com.howtodoinjava:Spring-Boot3-Demos:pom:1.0-SNAPSHOT and 'parent.relativePath' points at wrong local POM @ line 6, column 10 -> [Help 2]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/ProjectBuildingException
[ERROR] [Help 2] http://cwiki.apache.org/confluence/display/MAVEN/UnresolvableModelException
```